### PR TITLE
Use InputStream from server instead of storing entire file in memory

### DIFF
--- a/src/main/java/com/powsybl/cases/datasource/CaseDataSourceClient.java
+++ b/src/main/java/com/powsybl/cases/datasource/CaseDataSourceClient.java
@@ -108,48 +108,35 @@ public class CaseDataSourceClient implements ReadOnlyDataSource {
 
     @Override
     public InputStream newInputStream(String suffix, String ext) {
-        String path = UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
-                .queryParam("suffix", suffix)
-                .queryParam("ext", ext)
-                .buildAndExpand(caseUuid)
-                .toUriString();
-        try {
-            ResponseEntity<Resource> responseEntity = restTemplate.exchange(path,
-                                                                          HttpMethod.GET,
-                                                                          HttpEntity.EMPTY,
-                                                                          Resource.class);
-            Resource body = responseEntity.getBody();
-            if (body == null) {
-                throw new CaseDataSourceClientException("Response body is null for suffix: " + suffix + " and ext: " + ext);
-            }
-            return body.getInputStream();
-        } catch (HttpStatusCodeException e) {
-            throw new CaseDataSourceClientException("Exception when requesting the file inputStream: " + e.getResponseBodyAsString());
-        } catch (IOException e) {
-            throw new CaseDataSourceClientException("Exception when opening inputStream for suffix: " + suffix + " and ext: " + ext, e);
-        }
+        return fetchInputStream(UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
+                        .queryParam("suffix", suffix)
+                        .queryParam("ext", ext)
+                        .buildAndExpand(caseUuid)
+                        .toUriString(),
+                        "suffix: " + suffix + ", ext: " + ext);
     }
 
     @Override
     public InputStream newInputStream(String fileName) {
-        String path = UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
-                .queryParam("fileName", fileName)
-                .buildAndExpand(caseUuid)
-                .toUriString();
+        return fetchInputStream(UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
+                        .queryParam("fileName", fileName)
+                        .buildAndExpand(caseUuid)
+                        .toUriString(),
+                        "fileName: " + fileName);
+    }
+
+    private InputStream fetchInputStream(String path, String description) {
         try {
-            ResponseEntity<Resource> responseEntity = restTemplate.exchange(path,
-                                                                          HttpMethod.GET,
-                                                                          HttpEntity.EMPTY,
-                    Resource.class);
+            ResponseEntity<Resource> responseEntity = restTemplate.exchange(path, HttpMethod.GET, HttpEntity.EMPTY, Resource.class);
             Resource body = responseEntity.getBody();
             if (body == null) {
-                throw new CaseDataSourceClientException("Response body is null for fileName: " + fileName);
+                throw new CaseDataSourceClientException("Response body is null for " + description);
             }
             return body.getInputStream();
         } catch (HttpStatusCodeException e) {
-            throw new CaseDataSourceClientException("Exception when requesting the file inputStream: " + e.getResponseBodyAsString());
+            throw new CaseDataSourceClientException("HTTP error when requesting file inputStream for " + description + ": " + e.getResponseBodyAsString(), e);
         } catch (IOException e) {
-            throw new CaseDataSourceClientException("Exception when opening inputStream for fileName" + fileName, e);
+            throw new CaseDataSourceClientException("I/O error when opening inputStream for " + description, e);
         }
     }
 

--- a/src/main/java/com/powsybl/cases/datasource/CaseDataSourceClient.java
+++ b/src/main/java/com/powsybl/cases/datasource/CaseDataSourceClient.java
@@ -73,15 +73,7 @@ public class CaseDataSourceClient implements ReadOnlyDataSource {
                 .queryParam("ext", ext)
                 .buildAndExpand(caseUuid)
                 .toUriString();
-        try {
-            ResponseEntity<Boolean> responseEntity = restTemplate.exchange(path,
-                                                                           HttpMethod.GET,
-                                                                           HttpEntity.EMPTY,
-                                                                           Boolean.class);
-            return responseEntity.getBody();
-        } catch (HttpStatusCodeException e) {
-            throw new CaseDataSourceClientException("Exception when checking file existence: " + e.getResponseBodyAsString());
-        }
+        return checkFileExistence(path);
     }
 
     @Override
@@ -90,6 +82,10 @@ public class CaseDataSourceClient implements ReadOnlyDataSource {
                 .queryParam("fileName", fileName)
                 .buildAndExpand(caseUuid)
                 .toUriString();
+        return checkFileExistence(path);
+    }
+
+    private boolean checkFileExistence(String path) {
         try {
             ResponseEntity<Boolean> responseEntity = restTemplate.exchange(path,
                                                                            HttpMethod.GET,
@@ -108,21 +104,21 @@ public class CaseDataSourceClient implements ReadOnlyDataSource {
 
     @Override
     public InputStream newInputStream(String suffix, String ext) {
-        return fetchInputStream(UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
-                        .queryParam("suffix", suffix)
-                        .queryParam("ext", ext)
-                        .buildAndExpand(caseUuid)
-                        .toUriString(),
-                        "suffix: " + suffix + ", ext: " + ext);
+        String path = UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
+                .queryParam("suffix", suffix)
+                .queryParam("ext", ext)
+                .buildAndExpand(caseUuid)
+                .toUriString();
+        return fetchInputStream(path, "suffix: " + suffix + ", ext: " + ext);
     }
 
     @Override
     public InputStream newInputStream(String fileName) {
-        return fetchInputStream(UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
-                        .queryParam("fileName", fileName)
-                        .buildAndExpand(caseUuid)
-                        .toUriString(),
-                        "fileName: " + fileName);
+        String path = UriComponentsBuilder.fromPath("/" + CASE_API_VERSION + "/cases/{caseUuid}/datasource")
+                .queryParam("fileName", fileName)
+                .buildAndExpand(caseUuid)
+                .toUriString();
+        return fetchInputStream(path, "fileName: " + fileName);
     }
 
     private InputStream fetchInputStream(String path, String description) {

--- a/src/main/java/com/powsybl/cases/datasource/CaseDataSourceClient.java
+++ b/src/main/java/com/powsybl/cases/datasource/CaseDataSourceClient.java
@@ -109,7 +109,7 @@ public class CaseDataSourceClient implements ReadOnlyDataSource {
                 .queryParam("ext", ext)
                 .buildAndExpand(caseUuid)
                 .toUriString();
-        return fetchInputStream(path, "suffix: " + suffix + ", ext: " + ext);
+        return fetchInputStream(path);
     }
 
     @Override
@@ -118,21 +118,21 @@ public class CaseDataSourceClient implements ReadOnlyDataSource {
                 .queryParam("fileName", fileName)
                 .buildAndExpand(caseUuid)
                 .toUriString();
-        return fetchInputStream(path, "fileName: " + fileName);
+        return fetchInputStream(path);
     }
 
-    private InputStream fetchInputStream(String path, String description) {
+    private InputStream fetchInputStream(String path) {
         try {
             ResponseEntity<Resource> responseEntity = restTemplate.exchange(path, HttpMethod.GET, HttpEntity.EMPTY, Resource.class);
             Resource body = responseEntity.getBody();
             if (body == null) {
-                throw new CaseDataSourceClientException("Response body is null for " + description);
+                throw new CaseDataSourceClientException("Response body is null for " + path);
             }
             return body.getInputStream();
         } catch (HttpStatusCodeException e) {
-            throw new CaseDataSourceClientException("HTTP error when requesting file inputStream for " + description + ": " + e.getResponseBodyAsString(), e);
+            throw new CaseDataSourceClientException("Exception when requesting the file inputStream: " + e.getResponseBodyAsString());
         } catch (IOException e) {
-            throw new CaseDataSourceClientException("I/O error when opening inputStream for " + description, e);
+            throw new CaseDataSourceClientException("I/O error when opening inputStream for " + path, e);
         }
     }
 

--- a/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
+++ b/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
@@ -148,7 +148,7 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok().build());
 
         CaseDataSourceClientException exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A.xml"));
-        assertTrue(exception.getMessage().contains("Response body is null for fileName"));
+        assertEquals("Response body is null for fileName: A.xml", exception.getMessage());
 
         given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?suffix=A&ext=xml"),
                 eq(HttpMethod.GET),
@@ -157,7 +157,7 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok().build());
 
         exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A", "xml"));
-        assertTrue(exception.getMessage().contains("Response body is null for suffix"));
+        assertEquals("Response body is null for suffix: A, ext: xml", exception.getMessage());
     }
 
     @Test
@@ -171,7 +171,7 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok(resource));
 
         CaseDataSourceClientException exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A.xml"));
-        assertTrue(exception.getMessage().contains("Exception when opening inputStream for fileName"));
+        assertEquals("I/O error when opening inputStream for fileName: A.xml", exception.getMessage());
 
         given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?suffix=A&ext=xml"),
                 eq(HttpMethod.GET),
@@ -180,6 +180,6 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok(resource));
 
         exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A", "xml"));
-        assertTrue(exception.getMessage().contains("Exception when opening inputStream for suffix"));
+        assertEquals("I/O error when opening inputStream for suffix: A, ext: xml", exception.getMessage());
     }
 }

--- a/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
+++ b/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
@@ -148,7 +148,7 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok().build());
 
         CaseDataSourceClientException exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A.xml"));
-        assertEquals("Response body is null for fileName: A.xml", exception.getMessage());
+        assertTrue(exception.getMessage().contains("Response body is null for"));
 
         given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?suffix=A&ext=xml"),
                 eq(HttpMethod.GET),
@@ -157,7 +157,7 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok().build());
 
         exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A", "xml"));
-        assertEquals("Response body is null for suffix: A, ext: xml", exception.getMessage());
+        assertTrue(exception.getMessage().contains("Response body is null for"));
     }
 
     @Test
@@ -171,7 +171,7 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok(resource));
 
         CaseDataSourceClientException exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A.xml"));
-        assertEquals("I/O error when opening inputStream for fileName: A.xml", exception.getMessage());
+        assertTrue(exception.getMessage().contains("I/O error when opening inputStream for"));
 
         given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?suffix=A&ext=xml"),
                 eq(HttpMethod.GET),
@@ -180,6 +180,6 @@ class CaseDataSourceClientTest {
                 .willReturn(ResponseEntity.ok(resource));
 
         exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A", "xml"));
-        assertEquals("I/O error when opening inputStream for suffix: A, ext: xml", exception.getMessage());
+        assertTrue(exception.getMessage().contains("I/O error when opening inputStream for"));
     }
 }

--- a/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
+++ b/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
@@ -21,6 +21,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
@@ -28,8 +29,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -43,64 +43,74 @@ class CaseDataSourceClientTest {
     @Mock
     private RestTemplate caseServerRest;
 
+    @Mock
+    private Resource resource;
+
     private CaseDataSourceClient caseDataSourceClient;
+
+    private UUID caseUuid;
 
     @BeforeEach
     void setUp() {
-        final UUID randomUuid = UUID.randomUUID();
-        caseDataSourceClient = new CaseDataSourceClient(caseServerRest, randomUuid);
+        caseUuid = UUID.randomUUID();
+        caseDataSourceClient = new CaseDataSourceClient(caseServerRest, caseUuid);
+    }
 
+    @Test
+    void getBaseName() {
         given(caseServerRest.exchange(eq("/v1/cases/{caseUuid}/datasource/baseName"),
                 eq(HttpMethod.GET),
                 any(HttpEntity.class),
                 eq(String.class),
-                eq(randomUuid)))
+                eq(caseUuid)))
                 .willReturn(ResponseEntity.ok("myCaseName"));
 
-        ParameterizedTypeReference<Set<String>> parameterizedTypeReference = new ParameterizedTypeReference<>() { };
+        assertEquals("myCaseName", caseDataSourceClient.getBaseName());
+    }
 
-        given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource/list?regex=.*"),
+    @Test
+    void listName() {
+        ParameterizedTypeReference<Set<String>> parameterizedTypeReference = new ParameterizedTypeReference<>() {
+        };
+
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource/list?regex=.*"),
                 eq(HttpMethod.GET),
                 any(HttpEntity.class),
                 eq(parameterizedTypeReference)))
                 .willReturn(ResponseEntity.ok(new HashSet<>(asList("A.xml", "B.xml"))));
 
-        String data = "Data in the file";
-        byte[] responseBytes = data.getBytes();
-
-        given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource?fileName=A.xml"),
-                eq(HttpMethod.GET),
-                any(HttpEntity.class),
-                eq(Resource.class)))
-                .willReturn(ResponseEntity.ok(new InputStreamResource(new ByteArrayInputStream(responseBytes))));
-
-        given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource?suffix=A&ext=xml"),
-                eq(HttpMethod.GET),
-                any(HttpEntity.class),
-                eq(Resource.class)))
-                .willReturn(ResponseEntity.ok(new InputStreamResource(new ByteArrayInputStream(responseBytes))));
-
-        given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource/exists?fileName=A.xml"),
-                eq(HttpMethod.GET),
-                any(HttpEntity.class),
-                eq(Boolean.class)))
-                .willReturn(ResponseEntity.ok(true));
-
-        given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource/exists?suffix=A&ext=xml"),
-                eq(HttpMethod.GET),
-                any(HttpEntity.class),
-                eq(Boolean.class)))
-                .willReturn(ResponseEntity.ok(true));
+        assertEquals(new HashSet<>(asList("A.xml", "B.xml")), caseDataSourceClient.listNames(".*"));
     }
 
     @Test
-    void test() throws Exception {
-        assertEquals("myCaseName", caseDataSourceClient.getBaseName());
-
-        assertEquals(new HashSet<>(asList("A.xml", "B.xml")), caseDataSourceClient.listNames(".*"));
+    void exists() {
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource/exists?fileName=A.xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Boolean.class)))
+                .willReturn(ResponseEntity.ok(true));
 
         assertTrue(caseDataSourceClient.exists("A.xml"));
+
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource/exists?suffix=A&ext=xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Boolean.class)))
+                .willReturn(ResponseEntity.ok(true));
+
         assertTrue(caseDataSourceClient.exists("A", "xml"));
+    }
+
+    @Test
+    void newInputStream() throws IOException {
+        String data = "Data in the file";
+        byte[] responseBytes = data.getBytes();
+
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?fileName=A.xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok(new InputStreamResource(new ByteArrayInputStream(responseBytes))));
 
         try (InputStreamReader isReader = new InputStreamReader(caseDataSourceClient.newInputStream("A.xml"), StandardCharsets.UTF_8)) {
             BufferedReader reader = new BufferedReader(isReader);
@@ -112,6 +122,12 @@ class CaseDataSourceClientTest {
             assertEquals("Data in the file", datasourceResponse.toString());
         }
 
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?suffix=A&ext=xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok(new InputStreamResource(new ByteArrayInputStream(responseBytes))));
+
         try (InputStreamReader isReader = new InputStreamReader(caseDataSourceClient.newInputStream("A", "xml"), StandardCharsets.UTF_8)) {
             BufferedReader reader = new BufferedReader(isReader);
             StringBuilder datasourceResponse = new StringBuilder();
@@ -121,5 +137,49 @@ class CaseDataSourceClientTest {
             }
             assertEquals("Data in the file", datasourceResponse.toString());
         }
+    }
+
+    @Test
+    void newInputStreamWithEmptyBody() {
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?fileName=A.xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok().build());
+
+        CaseDataSourceClientException exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A.xml"));
+        assertTrue(exception.getMessage().contains("Response body is null for fileName"));
+
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?suffix=A&ext=xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok().build());
+
+        exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A", "xml"));
+        assertTrue(exception.getMessage().contains("Response body is null for suffix"));
+    }
+
+    @Test
+    void newInputStreamWithIOException() throws IOException {
+        given(resource.getInputStream()).willThrow(new IOException("Test"));
+
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?fileName=A.xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok(resource));
+
+        CaseDataSourceClientException exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A.xml"));
+        assertTrue(exception.getMessage().contains("Exception when opening inputStream for fileName"));
+
+        given(caseServerRest.exchange(eq("/v1/cases/" + caseUuid + "/datasource?suffix=A&ext=xml"),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok(resource));
+
+        exception = assertThrows(CaseDataSourceClientException.class, () -> caseDataSourceClient.newInputStream("A", "xml"));
+        assertTrue(exception.getMessage().contains("Exception when opening inputStream for suffix"));
     }
 }

--- a/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
+++ b/src/test/java/com/powsybl/cases/datasource/CaseDataSourceClientTest.java
@@ -12,12 +12,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
@@ -62,17 +65,20 @@ class CaseDataSourceClientTest {
                 eq(parameterizedTypeReference)))
                 .willReturn(ResponseEntity.ok(new HashSet<>(asList("A.xml", "B.xml"))));
 
+        String data = "Data in the file";
+        byte[] responseBytes = data.getBytes();
+
         given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource?fileName=A.xml"),
                 eq(HttpMethod.GET),
                 any(HttpEntity.class),
-                eq(byte[].class)))
-                .willReturn(ResponseEntity.ok("Data in the file".getBytes()));
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok(new InputStreamResource(new ByteArrayInputStream(responseBytes))));
 
         given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource?suffix=A&ext=xml"),
                 eq(HttpMethod.GET),
                 any(HttpEntity.class),
-                eq(byte[].class)))
-                .willReturn(ResponseEntity.ok("Data in the file".getBytes()));
+                eq(Resource.class)))
+                .willReturn(ResponseEntity.ok(new InputStreamResource(new ByteArrayInputStream(responseBytes))));
 
         given(caseServerRest.exchange(eq("/v1/cases/" + randomUuid + "/datasource/exists?fileName=A.xml"),
                 eq(HttpMethod.GET),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Case-server https://github.com/powsybl/powsybl-case-server/pull/71 now returns an InputStream, so we use this instead of recreating a stream from the entire byte array. 

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Recreate a stream from the byte array.


**What is the new behavior (if this is a feature change)?**
Stream directly the response from case-server (without having the complete byte array in memory).
Reduce duplication on endpoint suffix/ext vs filename.